### PR TITLE
Expose Admin Role Verification Endpoint with JWT Decoding

### DIFF
--- a/backend/controllers/adminController.js
+++ b/backend/controllers/adminController.js
@@ -5,9 +5,6 @@ const Student = require('../models/Student.js');
 const Professor = require('../models/Professor.js');
 const Subject = require('../models/Subject');
 const mongoose = require('mongoose');
-const fs = require('fs')
-const axios = require('axios');  
-const { chunk } = require("lodash");
 
 
 // Make sure you have bcryptjs installed
@@ -39,6 +36,34 @@ exports.registerAdmin = async (req, res) => {
   } catch (error) {
     console.error('Error during admin registration:', error); // Log the error for debugging
     res.status(500).json({ message: 'Something went wrong' });
+  }
+};
+
+
+exports.checkAdminRole = async (req, res) => {
+  try {
+    const authHeader = req.headers.authorization;
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return res.status(401).json({ message: 'Missing or invalid Authorization header' });
+    }
+
+    const token = authHeader.split(' ')[1];
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+
+    if (decoded.role !== 'admin') {
+      return res.status(403).json({ message: 'Access denied. Admins only.' });
+    }
+
+    return res.status(200).json({
+      message: 'Access granted. User is an admin.',
+      role: decoded.role,
+      userId: decoded.id,
+    });
+
+  } catch (error) {
+    console.error('Role verification failed:', error.message);
+    return res.status(401).json({ message: 'Invalid or expired token' });
   }
 };
 

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -1,6 +1,6 @@
 // src/routes/adminRoutes.js
 const express = require('express');
-const { registerAdmin, loginAdmin, getAllStudents, getAllProfessors, assignBasedOnChoices,assignFallbackElectives,clearSubjectsForAllStudents, getstudents} = require('../controllers/adminController.js');
+const { registerAdmin, loginAdmin, getAllStudents, getAllProfessors, assignBasedOnChoices,assignFallbackElectives,clearSubjectsForAllStudents, getstudents,checkAdminRole} = require('../controllers/adminController.js');
 const { authMiddleware, adminMiddleware } = require('../middleware/authMiddleware.js');
 
 const router = express.Router();
@@ -11,7 +11,7 @@ router.get('/students', authMiddleware, adminMiddleware, getAllStudents);
 router.get('/professors', authMiddleware, adminMiddleware, getAllProfessors);
 router.post('/chosen-electives', authMiddleware, adminMiddleware,assignBasedOnChoices );
 router.post('/nonchosen-electives', authMiddleware, adminMiddleware,assignFallbackElectives );
-
+router.get('/check-admin', checkAdminRole);
 
 router.post('/substudents', getstudents );
 router.delete('/electives',clearSubjectsForAllStudents );


### PR DESCRIPTION
This PR introduces backend enhancements to support role-based access control, specifically for verifying admin privileges directly from a frontend-provided JWT token.

✅ Key Changes:
Added a new controller (checkAdminRole) that:

Accepts a JWT token from the Authorization header.

Verifies and decodes the token using the server's secret.

Checks whether the user has the role 'admin'.

Returns appropriate access response without relying on middleware.

Useful for scenarios where the frontend needs to verify the current user's role before rendering protected views or routes.